### PR TITLE
- "vcd_nsxt_nat_rule" Module Release 1.3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.tfstate.*
 secrets.tfvars
 secrets.auto.tfvars
+terraform.tfvars
+terraform.auto.tfvars
 providers.tf
 
 # Crash log files

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## VCD NSX-T Edge Gateway NAT Rules Terraform Module
 
-This Terraform module will deploy NSX-T Edge Gateway NAT Rules into an existing VMware Cloud Director (VCD) Environment.  This module can be used to provsion new NAT Rules into [Rackspace Technology SDDC Flex](https://www.rackspace.com/cloud/private/software-defined-data-center-flex) VCD Data Center Regions.
+This Terraform module will deploy NSX-T Edge Gateway NAT Rules into an existing VMware Cloud Director (VCD) Environment.  This module can be used to provision new NAT Rules into [Rackspace Technology SDDC Flex](https://www.rackspace.com/cloud/private/software-defined-data-center-flex) VCD Data Center Regions.
 
 ## Requirements
 
@@ -38,7 +38,7 @@ This is an example of a `main.tf` file that uses the `"github.com/global-vmware/
 
 ```terraform
 module "vcd_nsxt_nat_rule" {
-  source                    = "github.com/global-vmware/vcd_nsxt_nat_rule.git?ref=v1.3.1"
+  source                    = "github.com/global-vmware/vcd_nsxt_nat_rule.git?ref=v1.3.2"
   
   vdc_org_name              = "<US1-VDC-ORG-NAME>"
   vdc_group_name            = "<US1-VDC-GRP-NAME>"

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ terraform {
 
 # Create the Datacenter Group data source
 data "vcd_vdc_group" "dcgroup" {
+  org       = var.vdc_org_name
   name      = var.vdc_group_name
 }
 


### PR DESCRIPTION
- "vcd_nsxt_nat_rule" Module Release 1.3.2

- Added the "org" Argument to the "vcd_vdc_group" Data Source

- Updated the source URL Reference in the "vcd_nsxt_nat_rule" Module Code Snippet to Version 1.3.2 in the Example Usage Section of the README